### PR TITLE
Fix executable name in .desktop file

### DIFF
--- a/data/dev.jamiethalacker.window_painter.desktop.in
+++ b/data/dev.jamiethalacker.window_painter.desktop.in
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=Window Painter
-Exec=window-painter
+Exec=window_painter
 Icon=dev.jamiethalacker.window_painter
 Terminal=false
 Type=Application


### PR DESCRIPTION
The executable is called `window_painter`, not `window-painter`.